### PR TITLE
Add monorepo create and project create empty commands

### DIFF
--- a/cmd/basil/main.go
+++ b/cmd/basil/main.go
@@ -12,7 +12,9 @@ import (
 
 	"github.com/gardenbed/basil-cli/internal/command"
 	configcmd "github.com/gardenbed/basil-cli/internal/command/config"
+	createmonorepocmd "github.com/gardenbed/basil-cli/internal/command/monorepo/create"
 	buildcmd "github.com/gardenbed/basil-cli/internal/command/project/build"
+	createprojectcmd "github.com/gardenbed/basil-cli/internal/command/project/create"
 	releasecmd "github.com/gardenbed/basil-cli/internal/command/project/release"
 	semvercmd "github.com/gardenbed/basil-cli/internal/command/project/semver"
 	updatecmd "github.com/gardenbed/basil-cli/internal/command/update"
@@ -67,6 +69,8 @@ func createCLI(ui cli.Ui, config config.Config, spec spec.Spec) *cli.CLI {
 	c.Commands = map[string]cli.CommandFactory{
 		"update":          updatecmd.NewFactory(ui, config),
 		"config":          configcmd.NewFactory(ui, config),
+		"monorepo create": createmonorepocmd.NewFactory(ui),
+		"project create":  createprojectcmd.NewFactory(ui),
 		"project semver":  semvercmd.NewFactory(ui),
 		"project build":   buildcmd.NewFactory(ui, spec),
 		"project release": releasecmd.NewFactory(ui, config, spec),

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,8 @@ Basil CLI is the command-line tool for [Basil](https://github.com/gardenbed/basi
 |---------|-------------|
 | `update` | Updates the Basil binary to the latest release. |
 | `config` | Sets the global configurations for Basil. |
+| `monorepo create` | Creates a new monorepo. |
+| `project create` | Creates a new project. |
 | `project semver` | Shows the current project [semantic version](https://semver.org). |
 | `project build` | Builds the project in the current directory. |
 | `project release` | Creates a new release using [semantic versioning](https://semver.org). |

--- a/internal/command/monorepo/create/create.go
+++ b/internal/command/monorepo/create/create.go
@@ -1,54 +1,48 @@
-package config
+package create
 
 import (
 	"context"
 	"flag"
-	"fmt"
 	"time"
 
-	"github.com/gardenbed/charm/askit"
 	"github.com/mitchellh/cli"
 
 	"github.com/gardenbed/basil-cli/internal/command"
-	"github.com/gardenbed/basil-cli/internal/config"
 )
 
 const (
 	timeout  = time.Minute
-	synopsis = `Configure Basil`
+	synopsis = `Create a new monorepo`
 	help     = `
-  Use this command for setting basil global configurations.
+  Use this command for creating a new monorepo.
 
-  Usage:  basil config
+  Usage:  basil monorepo create [flags]
+
+  Flags:
+    -name    the name of the new monorepo
 
   Examples:
-    basil config
+    basil monorepo create
+    basil monorepo create -name=go-monorepo
   `
 )
 
-type writeConfigFunc func(config.Config) (string, error)
-
-// Command is the cli.Command implementation for config command.
+// Command is the cli.Command implementation for create command.
 type Command struct {
-	ui     cli.Ui
-	config config.Config
-	funcs  struct {
-		writeConfig writeConfigFunc
-	}
+	ui cli.Ui
 }
 
 // New creates a new command.
-func New(ui cli.Ui, config config.Config) *Command {
+func New(ui cli.Ui) *Command {
 	return &Command{
-		ui:     ui,
-		config: config,
+		ui: ui,
 	}
 }
 
 // NewFactory returns a cli.CommandFactory for creating a new command.
-func NewFactory(ui cli.Ui, config config.Config) cli.CommandFactory {
+func NewFactory(ui cli.Ui) cli.CommandFactory {
 	return func() (cli.Command, error) {
-		return New(ui, config), nil
+		return New(ui), nil
 	}
 }
 
@@ -69,13 +63,11 @@ func (c *Command) Run(args []string) int {
 		return code
 	}
 
-	c.funcs.writeConfig = config.Write
-
 	return c.exec()
 }
 
 func (c *Command) parseFlags(args []string) int {
-	fs := flag.NewFlagSet("config", flag.ContinueOnError)
+	fs := flag.NewFlagSet("create", flag.ContinueOnError)
 
 	fs.Usage = func() {
 		c.ui.Output(c.Help())
@@ -94,24 +86,7 @@ func (c *Command) exec() int {
 	_, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	// ==============================> GET USER INPUTS <==============================
-
-	if err := askit.Ask(&c.config, c.ui); err != nil {
-		c.ui.Error(err.Error())
-		return command.ConfigError
-	}
-
-	// ==============================> WRITE CONFIG FILE <==============================
-
-	path, err := c.funcs.writeConfig(c.config)
-	if err != nil {
-		c.ui.Error(err.Error())
-		return command.ConfigError
-	}
-
 	// ==============================> DONE <==============================
-
-	c.ui.Info(fmt.Sprintf("Basil configurations written to %s", path))
 
 	return command.Success
 }

--- a/internal/command/monorepo/create/create_test.go
+++ b/internal/command/monorepo/create/create_test.go
@@ -1,0 +1,107 @@
+package create
+
+import (
+	"testing"
+
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gardenbed/basil-cli/internal/command"
+)
+
+func TestNew(t *testing.T) {
+	ui := cli.NewMockUi()
+	c := New(ui)
+
+	assert.NotNil(t, c)
+}
+
+func TestNewFactory(t *testing.T) {
+	ui := cli.NewMockUi()
+	c, err := NewFactory(ui)()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, c)
+}
+
+func TestCommand_Synopsis(t *testing.T) {
+	c := new(Command)
+	synopsis := c.Synopsis()
+
+	assert.NotEmpty(t, synopsis)
+}
+
+func TestCommand_Help(t *testing.T) {
+	c := new(Command)
+	help := c.Help()
+
+	assert.NotEmpty(t, help)
+}
+
+func TestCommand_Run(t *testing.T) {
+	t.Run("InvalidFlag", func(t *testing.T) {
+		c := &Command{ui: cli.NewMockUi()}
+		exitCode := c.Run([]string{"-undefined"})
+
+		assert.Equal(t, command.FlagError, exitCode)
+	})
+
+	t.Run("OK", func(t *testing.T) {
+		c := &Command{ui: cli.NewMockUi()}
+		c.Run([]string{})
+
+		// TODO: assertions
+	})
+}
+
+func TestCommand_parseFlags(t *testing.T) {
+	tests := []struct {
+		name             string
+		args             []string
+		expectedExitCode int
+	}{
+		{
+			name:             "InvalidFlag",
+			args:             []string{"-undefined"},
+			expectedExitCode: command.FlagError,
+		},
+		{
+			name:             "NoFlag",
+			args:             []string{},
+			expectedExitCode: command.Success,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Command{ui: cli.NewMockUi()}
+			exitCode := c.parseFlags(tc.args)
+
+			assert.Equal(t, tc.expectedExitCode, exitCode)
+		})
+	}
+}
+
+func TestCommand_exec(t *testing.T) {
+	tests := []struct {
+		name             string
+		expectedExitCode int
+	}{
+		{
+			name:             "OK",
+			expectedExitCode: command.Success,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Command{
+				ui: cli.NewMockUi(),
+			}
+
+			exitCode := c.exec()
+
+			assert.Equal(t, tc.expectedExitCode, exitCode)
+		})
+	}
+}

--- a/internal/command/project/build/build.go
+++ b/internal/command/project/build/build.go
@@ -89,7 +89,7 @@ type Command struct {
 	}
 }
 
-// New creates a build command.
+// New creates a new command.
 func New(ui cli.Ui, spec spec.Spec) *Command {
 	return &Command{
 		ui:   ui,
@@ -97,7 +97,7 @@ func New(ui cli.Ui, spec spec.Spec) *Command {
 	}
 }
 
-// NewFactory returns a cli.CommandFactory for creating a build command.
+// NewFactory returns a cli.CommandFactory for creating a new command.
 func NewFactory(ui cli.Ui, spec spec.Spec) cli.CommandFactory {
 	return func() (cli.Command, error) {
 		return New(ui, spec), nil

--- a/internal/command/project/create/create_test.go
+++ b/internal/command/project/create/create_test.go
@@ -1,0 +1,107 @@
+package create
+
+import (
+	"testing"
+
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gardenbed/basil-cli/internal/command"
+)
+
+func TestNew(t *testing.T) {
+	ui := cli.NewMockUi()
+	c := New(ui)
+
+	assert.NotNil(t, c)
+}
+
+func TestNewFactory(t *testing.T) {
+	ui := cli.NewMockUi()
+	c, err := NewFactory(ui)()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, c)
+}
+
+func TestCommand_Synopsis(t *testing.T) {
+	c := new(Command)
+	synopsis := c.Synopsis()
+
+	assert.NotEmpty(t, synopsis)
+}
+
+func TestCommand_Help(t *testing.T) {
+	c := new(Command)
+	help := c.Help()
+
+	assert.NotEmpty(t, help)
+}
+
+func TestCommand_Run(t *testing.T) {
+	t.Run("InvalidFlag", func(t *testing.T) {
+		c := &Command{ui: cli.NewMockUi()}
+		exitCode := c.Run([]string{"-undefined"})
+
+		assert.Equal(t, command.FlagError, exitCode)
+	})
+
+	t.Run("OK", func(t *testing.T) {
+		c := &Command{ui: cli.NewMockUi()}
+		c.Run([]string{})
+
+		// TODO: assertions
+	})
+}
+
+func TestCommand_parseFlags(t *testing.T) {
+	tests := []struct {
+		name             string
+		args             []string
+		expectedExitCode int
+	}{
+		{
+			name:             "InvalidFlag",
+			args:             []string{"-undefined"},
+			expectedExitCode: command.FlagError,
+		},
+		{
+			name:             "NoFlag",
+			args:             []string{},
+			expectedExitCode: command.Success,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Command{ui: cli.NewMockUi()}
+			exitCode := c.parseFlags(tc.args)
+
+			assert.Equal(t, tc.expectedExitCode, exitCode)
+		})
+	}
+}
+
+func TestCommand_exec(t *testing.T) {
+	tests := []struct {
+		name             string
+		expectedExitCode int
+	}{
+		{
+			name:             "OK",
+			expectedExitCode: command.Success,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Command{
+				ui: cli.NewMockUi(),
+			}
+
+			exitCode := c.exec()
+
+			assert.Equal(t, tc.expectedExitCode, exitCode)
+		})
+	}
+}

--- a/internal/command/project/release/release.go
+++ b/internal/command/project/release/release.go
@@ -168,7 +168,7 @@ type Command struct {
 	}
 }
 
-// New creates a release command.
+// New creates a new command.
 func New(ui cli.Ui, config config.Config, spec spec.Spec) *Command {
 	return &Command{
 		ui:     ui,
@@ -177,7 +177,7 @@ func New(ui cli.Ui, config config.Config, spec spec.Spec) *Command {
 	}
 }
 
-// NewFactory returns a cli.CommandFactory for creating a release command.
+// NewFactory returns a cli.CommandFactory for creating a new command.
 func NewFactory(ui cli.Ui, config config.Config, spec spec.Spec) cli.CommandFactory {
 	return func() (cli.Command, error) {
 		return New(ui, config, spec), nil

--- a/internal/command/project/semver/semver.go
+++ b/internal/command/project/semver/semver.go
@@ -47,14 +47,14 @@ type Command struct {
 	}
 }
 
-// New creates a semver command.
+// New creates a new command.
 func New(ui cli.Ui) *Command {
 	return &Command{
 		ui: ui,
 	}
 }
 
-// NewFactory returns a cli.CommandFactory for creating a semver command.
+// NewFactory returns a cli.CommandFactory for creating a new command.
 func NewFactory(ui cli.Ui) cli.CommandFactory {
 	return func() (cli.Command, error) {
 		return New(ui), nil

--- a/internal/command/update/update.go
+++ b/internal/command/update/update.go
@@ -51,7 +51,7 @@ type Command struct {
 	}
 }
 
-// New creates an update command.
+// New creates a new command.
 func New(ui cli.Ui, config config.Config) *Command {
 	return &Command{
 		ui:     ui,
@@ -59,7 +59,7 @@ func New(ui cli.Ui, config config.Config) *Command {
 	}
 }
 
-// NewFactory returns a cli.CommandFactory for creating an update command.
+// NewFactory returns a cli.CommandFactory for creating a new command.
 func NewFactory(ui cli.Ui, config config.Config) cli.CommandFactory {
 	return func() (cli.Command, error) {
 		return New(ui, config), nil


### PR DESCRIPTION
## Description

  - [x] Add empty `monorepo create` command
  - [x] Add empty `project create` command

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Tests are provided for the new change
